### PR TITLE
Rename algolia.api_key and add a description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,7 +39,12 @@ kramdown:
 algolia:
   application_id: 'E642SEDTHL'
   index_name: 'devdocs'
-  api_key: 'd2d0f33ab73e291ef8d88d8b565e754c'
+
+  # search-only API key allows to search data immediately.
+  # It is safe to use in production front-end code.
+  # Used at src/_includes/layout/header-scripts.html
+  # For more details, refer to: https://www.algolia.com/doc/guides/security/api-keys/#search-only-api-key
+  search_only_key: 'd2d0f33ab73e291ef8d88d8b565e754c'
 
 defaults:
   -

--- a/src/_includes/layout/header-scripts.html
+++ b/src/_includes/layout/header-scripts.html
@@ -4,7 +4,7 @@
   var algolia = {
     id : "{{ site.algolia.application_id}}",
     index:  "{{ site.algolia.index_name}}",
-    key:  "{{ site.algolia.api_key}}"
+    key:  "{{ site.algolia.search_only_key}}"
   };
 
   var indices = [


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) renames the `algolia.api_key` to `algolia.search_only_key` and adds some documentation to avoid any security alerts in the future.